### PR TITLE
Trigger rework

### DIFF
--- a/lib/GDMBasics/src/Game.cpp
+++ b/lib/GDMBasics/src/Game.cpp
@@ -121,7 +121,7 @@ u_int Game::addSecondaryTarget(sf::View view)
             }
         }
 
-        _trigger_manager.curate();
+        _active_room->curateTriggers();
 
         // Todo: Data loop
         _active_room->dataLoop();

--- a/lib/GDMBasics/src/Trigger.cpp
+++ b/lib/GDMBasics/src/Trigger.cpp
@@ -5,24 +5,5 @@
 
 namespace mate
 {
-sf::Vector2f Trigger::getPosition() const
-{
-    sf::Vector2f reference(0, 0);
-    if (std::shared_ptr<Element> spt_parent = _follow.lock())
-    {
-        reference = spt_parent->getWorldPosition();
-    }
-    return _offset.getPositionBounds(reference);
-}
-
-sf::Vector2f Trigger::getDimensions() const
-{
-    sf::Vector2f reference(1, 1);
-    if (std::shared_ptr<Element> spt_parent = _follow.lock())
-    {
-        reference = spt_parent->getWorldScale();
-    }
-    return _offset.getDimensionBounds(reference);
-}
 
 } // namespace mate

--- a/lib/GDMBasics/src/TriggerManager.cpp
+++ b/lib/GDMBasics/src/TriggerManager.cpp
@@ -26,8 +26,8 @@ void TriggerManager::checkTrigger(ShapeType shape, const TriggerShooter &shooter
 
     for (const std::unique_ptr<Trigger> &trigger : triggers)
     {
-        sf::Vector2 trig_position = trigger->getPosition();
-        sf::Vector2 trig_dimensions = trigger->getDimensions();
+        sf::Vector2 trig_position = trigger->getWorldPosition();
+        sf::Vector2 trig_dimensions = trigger->getWorldScale();
 
         switch (trigger->shape)
         {
@@ -76,8 +76,6 @@ void TriggerManager::checkTrigger(ShapeType shape, const TriggerShooter &shooter
             }
             break;
         }
-
-        trigger->checkRemove();
     }
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -20,7 +20,7 @@ class ColorTrigger : public Trigger
     std::weak_ptr<Sprite> _sprite;
 
   public:
-    explicit ColorTrigger(const std::weak_ptr<Element> &parent) : Trigger(parent, true)
+    explicit ColorTrigger(const std::shared_ptr<Element> &parent) : Trigger(parent)
     {
     }
 
@@ -44,11 +44,12 @@ game_instance start()
     auto camElem = mainRoom->addElement();
     //*camera component
     auto camera = camElem->addComponent<mate::Camera>();
-    camera->setScaleType(mate::Camera::ScaleType::REVEAL);
+    camera->setScaleType(mate::Camera::ScaleType::RESCALE);
 
     auto camElem2 = mainRoom->addElement();
     //*camera component
     auto camera2 = camElem2->addComponent<mate::Camera>();
+    camera2->setScaleType(mate::Camera::ScaleType::REVEAL);
     camera2->useNewTarget();
 
     auto sptElem0 = mainRoom->addElement();
@@ -74,7 +75,7 @@ game_instance start()
     camera->addSprite((child0->addComponent<mate::Sprite>()));
 
     auto child1 = sptElem0->addChild();
-    child1->depth = -1;
+    child1->depth = -2;
     child1->setPosition(55, 0);
     child1->setScale(0.5, 0.5);
     camera->addSprite((child1->addComponent<mate::Sprite>()));
@@ -87,6 +88,8 @@ game_instance start()
     auto sprite2 = sptElem1->addComponent<mate::Sprite>();
     sprite2->setTexture("../Circle.png");
     sprite2->setColor(sf::Color::Magenta);
+    sprite2->setSpriteDepth(20);
+    camera->addSprite(sprite2);
     camera2->addSprite(sprite2);
     // sprite2->setDepth(-10);
     // ColorTrigger
@@ -95,7 +98,7 @@ game_instance start()
     // color->getID());
     color->addSprite(sprite2);
     color->shape = mate::CIRCLE;
-    color->setDimensionOffset(64, 64);
+    color->setScale(64, 64);
     game->addTrigger(std::move(color));
 
     input1->addInput(sf::Keyboard::W, &mate::Element::destroy, sptElem1);


### PR DESCRIPTION
- Triggers where keept on a TriggerManager instance on Game, this would make them persist tru Rooms unless a manual cleaning was performed.
- To fix that issue Game doesn't have a TriggerManager anymore, instead each Room has an instance of TriggerManager to keep track of it's contained Triggers.
- Trigger now inherit from Element, this makes Trigger::offset useless since the Trigger itself has a LocalCoords independent of any other object.
- For that reson Trigger::offset and it's related methods where removed.
- The classes Declarations on GDMBasics where moved arround since now Room requires TriggerManager's declaration and Trigger requires Element's declaration.
- TriggerManager::checkTrigger() was modified to use Trigger::getWorldPosition() and Trigger::getWorldScale()

```mermaid
---
title: Trigger-Room-Game new relationship
---
classDiagram
    class Game
    Game : - list_of_rooms
    Game : - one_active_room

    class Room
    Room --* Game
    Room : - list_of_elements
    Room : - trigger_manager_instance

    class TriggerManager
    TriggerManager --* Room
    TriggerManager : - list_of_active_triggers

    class Element
    Element --o Room
    Element : - list_of_elements
    Element : - list_of_components

    Trigger --|> Element
    Trigger .. TriggerManager
```

```mermaid
---
title: TriggerShooter superposition check sequence
---
sequenceDiagram
    participant Game
    participant Room
    participant TriggerManager
    participant Trigger
    participant ET as Element/Trigger
    participant C as Component: TriggerShooter

    Game ->>+ Room : loop()
    Room ->>+ ET : loop()
    ET ->>+ C : loop()
    C -->> Game : Do I superpose an active Trigger?
    Game -->> Room : The active Room knows which Triggers are active
    Room -->>+ TriggerManager : check if this superpose an active Trigger
    alt it does
        TriggerManager ->> Trigger : Run triggerIn() implementation
    end
    TriggerManager -->>- Room : finished
    Room -->> Game : finished
    Game -->> C : finished
    C -->>- ET : finished
    ET -->>- Room : finished
    Room -->>- Game : finished
```

As you can see, the sequence is not very clean, it can most certantly be do better, but for the moment it works.

## Future improvements
- Since a Trigger can hold Components a TriggerShooter can be associated to a Trigger and the trigger will be superposed every frame. For that a quick and easy solution will be to add layers to Triggers and TriggerShooters so when on different layers the collision becomes imposible.
- A direct line of communications between TriggerShooter and Room or even TriggerManager could make the sequence way more simple, but that could mean that an active TriggerShooter might be able to trigger inactive Triggers, that last effect is not desirable.