### PR TITLE
General classes restructure

### DIFF
--- a/lib/GDMBasics/include/Camera.h
+++ b/lib/GDMBasics/include/Camera.h
@@ -107,7 +107,10 @@ class Camera : public Component
         return _visible_sprites.back();
     }
 
-    sf::View getView() const { return _view; }
+    sf::View getView() const
+    {
+        return _view;
+    }
 #endif
 };
 } // namespace mate

--- a/lib/GDMBasics/include/GDMBasics.h
+++ b/lib/GDMBasics/include/GDMBasics.h
@@ -183,7 +183,6 @@ class Element : public mate::LocalCoords, public ILowLoop
 {
   private:
     std::list<std::shared_ptr<ILowLoop>> _children;
-    bool _destroy_flag = false;
 
   public:
     // Constructors

--- a/lib/GDMBasics/include/GDMBasics.h
+++ b/lib/GDMBasics/include/GDMBasics.h
@@ -384,17 +384,24 @@ class TriggerManager
 class Room : public mate::LocalCoords, public TriggerManager, public ILoop
 {
   private:
-    std::list<std::shared_ptr<Element>> _elements; ///< Elements within the Room.
+    std::list<std::shared_ptr<ILowLoop>> _children_loops; ///< Elements within the Room.
 
   public:
     // Constructors
     Room() = default;
 
-    // Element stuff
-    [[maybe_unused]] unsigned long getElementsCount()
+#ifdef GDM_TESTING_ENABLED
+    template <class T> unsigned long getLoopTypeCount()
     {
-        return _elements.size();
+        ulong count = 0;
+        for (const auto& loop : _children_loops){
+            if(std::dynamic_pointer_cast<T>(loop)){
+                count++;
+            }
+        }
+        return count;
     }
+#endif
     /**
      * @brief Adds a preexisting Element to the Room.
      *

--- a/lib/GDMBasics/include/GDMBasics.h
+++ b/lib/GDMBasics/include/GDMBasics.h
@@ -161,11 +161,11 @@ concept valid_component = std::is_base_of<Component, T>::value && requires(std::
 class Component : public ILowLoop
 {
   public:
-    explicit Component(std::weak_ptr<class Element> parent) : _parent(std::move(parent))
+    explicit Component(std::weak_ptr<class LocalCoords> parent) : _parent(std::move(parent))
     {
     }
   protected:
-    std::weak_ptr<Element> _parent; ///< Element that contains the Component and controls it's destruction.
+    std::weak_ptr<LocalCoords> _parent; ///< Element that contains the Component and controls it's destruction.
 };
 
 /**

--- a/lib/GDMBasics/include/InputActions.h
+++ b/lib/GDMBasics/include/InputActions.h
@@ -93,13 +93,15 @@ class InputActions : public Component
     void loop() override;
 
 #ifdef GDM_TESTING_ENABLED
-    uint getActionsCount(){
+    uint getActionsCount()
+    {
         return _actions.size();
     }
 #endif
 };
 
-inline bool _isKeyPressedFunc(sf::Keyboard::Key key) {
+inline bool _isKeyPressedFunc(sf::Keyboard::Key key)
+{
     return sf::Keyboard::isKeyPressed(key);
 }
 

--- a/lib/GDMBasics/include/LocalCoords.h
+++ b/lib/GDMBasics/include/LocalCoords.h
@@ -131,8 +131,7 @@ class LocalCoords : public sf::Transformable, public std::enable_shared_from_thi
     /**
      * @deprecated depth is now a public variable.
      */
-     [[deprecated]]
-    int getDepth() const
+    [[deprecated]] int getDepth() const
     {
         return depth;
     }
@@ -142,8 +141,7 @@ class LocalCoords : public sf::Transformable, public std::enable_shared_from_thi
     /**
      * @deprecated depth is now a public variable.
      */
-     [[deprecated]]
-    void setDepth(int depth_)
+    [[deprecated]] void setDepth(int depth_)
     {
         depth = depth_;
     }

--- a/lib/GDMBasics/src/Camera.cpp
+++ b/lib/GDMBasics/src/Camera.cpp
@@ -47,7 +47,7 @@ void Camera::renderLoop()
         return;
     }
 
-    if (std::shared_ptr<Element> spt_parent = _parent.lock())
+    if (std::shared_ptr<LocalCoords> spt_parent = _parent.lock())
     {
         _view.setCenter(spt_parent->getWorldPosition());
         _view.setRotation(spt_parent->getWorldRotation());

--- a/lib/GDMBasics/src/Element.cpp
+++ b/lib/GDMBasics/src/Element.cpp
@@ -9,14 +9,14 @@ namespace mate
 std::shared_ptr<Element> Element::addChild()
 {
     auto child = std::make_shared<Element>(shared_from_this(), getPosition());
-    _elements.push_back(child);
+    _children.push_back(child);
     return std::move(child);
 }
 
 void Element::destroy()
 {
     _destroy_flag = true;
-    for (auto &element : _elements)
+    for (auto &element : _children)
     {
         element->destroy();
     }
@@ -24,40 +24,32 @@ void Element::destroy()
 
 void Element::loop()
 {
-    _components.remove_if([](auto &component) { return component->shouldDestroy(); });
-
     if (!_destroy_flag)
     {
-        for (const auto &component : _components)
+        for (const auto &child : _children)
         {
-            component->loop();
+            child->loop();
             if (_destroy_flag)
                 break;
         }
     }
 
-    for (auto &element : _elements)
-    {
-        element->loop();
-    }
-
     if (_destroy_flag)
     {
-        _components.clear();
-        _elements.clear();
+        _children.clear();
     }
 
-    _elements.remove_if([](auto &element) { return element->shouldDestroy(); });
+    _children.remove_if([](auto &child) { return child->shouldDestroy(); });
 }
 
 void Element::renderLoop()
 {
-    for (auto &element : _elements)
+    for (auto &element : _children)
     {
         element->renderLoop();
     }
 
-    for (const auto &component : _components)
+    for (const auto &component : _children)
     {
         component->renderLoop();
     }
@@ -65,23 +57,40 @@ void Element::renderLoop()
 
 void Element::windowResizeEvent()
 {
-    for (auto &element : _elements)
+    for (auto &element : _children)
     {
         element->windowResizeEvent();
     }
 
-    for (const auto &component : _components)
+    for (const auto &component : _children)
     {
         component->windowResizeEvent();
     }
 }
 
+unsigned long Element::getElementsCount() const
+{
+    ulong count = 0;
+    for (const auto &child : _children)
+    {
+        if (std::dynamic_pointer_cast<Element>(child))
+        {
+            ++count;
+        }
+    }
+    return count;
+}
+
 unsigned long Element::getFullElementsCount()
 {
-    unsigned long count = _elements.size();
-    for (auto &element : _elements)
+    unsigned long count = 0;
+    for (const auto &child : _children)
     {
-        count += element->getFullElementsCount();
+        if (auto element = std::dynamic_pointer_cast<Element>(child))
+        {
+            ++count;
+            count += element->getFullElementsCount();
+        }
     }
     return count;
 }

--- a/lib/GDMBasics/src/Element.cpp
+++ b/lib/GDMBasics/src/Element.cpp
@@ -24,13 +24,15 @@ void Element::destroy()
 
 void Element::loop()
 {
+    _components.remove_if([](auto &component) { return component->shouldDestroy(); });
+
     if (!_destroy_flag)
     {
         for (const auto &component : _components)
         {
+            component->loop();
             if (_destroy_flag)
                 break;
-            component->loop();
         }
     }
 
@@ -61,11 +63,11 @@ void Element::renderLoop()
     }
 }
 
-void Element::resizeEvent()
+void Element::windowResizeEvent()
 {
     for (auto &element : _elements)
     {
-        element->resizeEvent();
+        element->windowResizeEvent();
     }
 
     for (const auto &component : _components)

--- a/lib/GDMBasics/src/Element.cpp
+++ b/lib/GDMBasics/src/Element.cpp
@@ -16,9 +16,14 @@ std::shared_ptr<Element> Element::addChild()
 void Element::destroy()
 {
     _destroy_flag = true;
-    for (auto &element : _children)
+    for (auto &child : _children)
     {
-        element->destroy();
+        if(auto element = std::dynamic_pointer_cast<Element>(child)){
+            element->destroy();
+        } else
+        {
+            child->destroy();
+        }
     }
 }
 

--- a/lib/GDMBasics/src/Game.cpp
+++ b/lib/GDMBasics/src/Game.cpp
@@ -193,7 +193,7 @@ void Game::runSingleFrame()
         case sf::Event::Closed:
             exit(EXIT_SUCCESS);
         case sf::Event::Resized:
-            _active_room->resizeEvent();
+            _active_room->windowResizeEvent();
             break;
         default:
             break;
@@ -209,7 +209,7 @@ void Game::runSingleFrame()
             case sf::Event::Closed:
                 target.target->setVisible(false);
             case sf::Event::Resized:
-                _active_room->resizeEvent();
+                _active_room->windowResizeEvent();
                 break;
             default:
                 break;
@@ -222,7 +222,7 @@ void Game::runSingleFrame()
     _active_room->curateTriggers();
 
     // Todo: Data loop
-    _active_room->dataLoop();
+    _active_room->loop();
 
     // Todo: Render Loop
     _main_render_target.target->clear();

--- a/lib/GDMBasics/src/LocalCoords.cpp
+++ b/lib/GDMBasics/src/LocalCoords.cpp
@@ -33,8 +33,9 @@ namespace mate
     setRotation(rotation);
 }
 
-[[maybe_unused]] LocalCoords::LocalCoords(sf::Vector2f position, sf::Vector2f scale, const std::shared_ptr<LocalCoords> &parent)
-    :_parent(parent)
+[[maybe_unused]] LocalCoords::LocalCoords(sf::Vector2f position, sf::Vector2f scale,
+                                          const std::shared_ptr<LocalCoords> &parent)
+    : _parent(parent)
 {
     setPosition(position);
     setScale(scale);

--- a/lib/GDMBasics/src/Room.cpp
+++ b/lib/GDMBasics/src/Room.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<Element> Room::addElement()
     return std::move(child_element);
 }
 
-void Room::dataLoop()
+void Room::loop()
 {
 
     for (auto &element : _elements)
@@ -39,11 +39,11 @@ void Room::renderLoop()
     }
 }
 
-[[maybe_unused]] void Room::resizeEvent()
+[[maybe_unused]] void Room::windowResizeEvent()
 {
     for (auto &element : _elements)
     {
-        element->resizeEvent();
+        element->windowResizeEvent();
     }
 }
 } // namespace mate

--- a/lib/GDMBasics/src/Room.cpp
+++ b/lib/GDMBasics/src/Room.cpp
@@ -10,30 +10,30 @@ namespace mate
 {
     if (weakPtrIsUninitialized(element->getParent()))
         element->setParent(shared_from_this());
-    _elements.push_back(std::move(element));
+    _children_loops.push_back(std::move(element));
 }
 
 std::shared_ptr<Element> Room::addElement()
 {
     auto child_element = std::make_shared<Element>(shared_from_this(), getPosition());
-    _elements.push_back(child_element);
+    _children_loops.push_back(child_element);
     return std::move(child_element);
 }
 
 void Room::loop()
 {
 
-    for (auto &element : _elements)
+    for (auto &element : _children_loops)
     {
         element->loop();
     }
 
-    _elements.remove_if([](auto &element) { return element->shouldDestroy(); });
+    _children_loops.remove_if([](auto &element) { return element->shouldDestroy(); });
 }
 
 void Room::renderLoop()
 {
-    for (auto &element : _elements)
+    for (auto &element : _children_loops)
     {
         element->renderLoop();
     }
@@ -41,7 +41,7 @@ void Room::renderLoop()
 
 [[maybe_unused]] void Room::windowResizeEvent()
 {
-    for (auto &element : _elements)
+    for (auto &element : _children_loops)
     {
         element->windowResizeEvent();
     }

--- a/lib/GDMBasics/src/Room.cpp
+++ b/lib/GDMBasics/src/Room.cpp
@@ -22,13 +22,11 @@ std::shared_ptr<Element> Room::addElement()
 
 void Room::loop()
 {
-
-    for (auto &element : _children_loops)
+    for (const auto &child : _children_loops)
     {
-        element->loop();
+        child->loop();
     }
-
-    _children_loops.remove_if([](auto &element) { return element->shouldDestroy(); });
+    _children_loops.remove_if([](auto &child) { return child->shouldDestroy(); });
 }
 
 void Room::renderLoop()

--- a/lib/GDMBasics/src/Sprite.cpp
+++ b/lib/GDMBasics/src/Sprite.cpp
@@ -35,7 +35,7 @@ void Sprite::loop()
 {
     if (_actualize)
     {
-        if (std::shared_ptr<Element> spt_parent = _parent.lock())
+        if (std::shared_ptr<LocalCoords> spt_parent = _parent.lock())
         {
             _sprite->sprite.setScale(offset.getDimensionBounds(spt_parent->getWorldScale()));
             _sprite->sprite.setRotation(spt_parent->getWorldRotation());

--- a/lib/GDMBasics/src/TriggerManager.cpp
+++ b/lib/GDMBasics/src/TriggerManager.cpp
@@ -11,7 +11,7 @@ void TriggerManager::removeTrigger(int trigger_id)
     {
         if (trigger->getID() == trigger_id)
         {
-            trigger->markForRemoval();
+            trigger->destroy();
         }
     }
 }

--- a/lib/GDMBasics/src/TriggerShooter.cpp
+++ b/lib/GDMBasics/src/TriggerShooter.cpp
@@ -8,7 +8,7 @@ namespace mate
 {
 sf::Vector2f TriggerShooter::getPosition() const
 {
-    if (std::shared_ptr<Element> spt_parent = _parent.lock())
+    if (std::shared_ptr<LocalCoords> spt_parent = _parent.lock())
     {
         return offset.getPositionBounds(spt_parent->getWorldPosition());
     }
@@ -17,7 +17,7 @@ sf::Vector2f TriggerShooter::getPosition() const
 
 sf::Vector2f TriggerShooter::getDimensions() const
 {
-    if (std::shared_ptr<Element> spt_parent = _parent.lock())
+    if (std::shared_ptr<LocalCoords> spt_parent = _parent.lock())
     {
         return offset.getDimensionBounds(spt_parent->getWorldScale());
     }

--- a/tests/Basics/test_Basics.cpp
+++ b/tests/Basics/test_Basics.cpp
@@ -76,20 +76,20 @@ TEST(BasicsTest, TopElementCreationAndDestruction)
 
     // Assert if the element was properly created
     auto test_element = main_room->addElement();
-    ASSERT_EQ(main_room->getElementsCount(), 1);
+    ASSERT_EQ(main_room->getLoopTypeCount<mate::Element>(), 1);
 
     // Assert if the element was properly destroyed
     test_element->destroy();
     game->runSingleFrame();
-    EXPECT_EQ(main_room->getElementsCount(), 0);
+    EXPECT_EQ(main_room->getLoopTypeCount<mate::Element>(), 0);
 
     auto element_b = std::make_shared<mate::Element>();
     main_room->addElement(element_b);
-    ASSERT_EQ(main_room->getElementsCount(), 1);
+    ASSERT_EQ(main_room->getLoopTypeCount<mate::Element>(), 1);
 
     element_b->destroy();
     game->runSingleFrame();
-    EXPECT_EQ(main_room->getElementsCount(), 0);
+    EXPECT_EQ(main_room->getLoopTypeCount<mate::Element>(), 0);
 }
 
 float getAngle(float angle){
@@ -150,7 +150,7 @@ TEST(BasicsTest, ChildElementCreationAndDestruction)
     auto child_element = parent_element->addChild();
     auto second_child_element = parent_element->addChild();
 
-    ASSERT_EQ(main_room->getElementsCount(), 1);
+    ASSERT_EQ(main_room->getLoopTypeCount<mate::Element>(), 1);
     ASSERT_EQ(parent_element->getElementsCount(), 2);
     ASSERT_EQ(parent_element->getFullElementsCount(), 2);
 

--- a/tests/Basics/test_Basics.cpp
+++ b/tests/Basics/test_Basics.cpp
@@ -161,7 +161,7 @@ TEST(BasicsTest, ChildElementCreationAndDestruction)
     ASSERT_EQ(parent_element->getFullElementsCount(), 3);
 
     child_element->destroy();
-    game->runSingleFrame();
+    main_room->loop();
 
     ASSERT_EQ(parent_element->getElementsCount(), 1);
     ASSERT_EQ(parent_element->getFullElementsCount(), 1);
@@ -267,16 +267,4 @@ TEST(BasicsTest, WeakPointerIsUninitialized){
     EXPECT_EQ(mate::weakPtrIsUninitialized(room), false);
     EXPECT_EQ(mate::weakPtrIsUninitialized(element), false);
 }
-
-
-
-/*TEST(BasicsTest, ComponentCreation){
-    auto room = std::make_shared<mate::Room>();
-    mate::Element element(room);
-    auto sprite = element.addComponent<mate::Sprite>();
-
-    ASSERT_NE(element.getComponent<mate::Sprite>(), nullptr);
-    ASSERT_EQ(element.getComponent<mate::Camera>(), nullptr);
-    ASSERT_EQ(element.getComponent<mate::Sprite>(), sprite);
-}*/
 

--- a/tests/InputActions/test_InputActions.cpp
+++ b/tests/InputActions/test_InputActions.cpp
@@ -18,7 +18,7 @@ TEST(InputActionsTest, FunctionActionCalls){
     mate::isKeyPressed = [](sf::Keyboard::Key key){
         return false;
     };
-    room->dataLoop();
+    room->loop();
     ASSERT_EQ(test_bool, false);
 
     mate::isKeyPressed = [](sf::Keyboard::Key key){
@@ -26,7 +26,7 @@ TEST(InputActionsTest, FunctionActionCalls){
             return false;
         return true;
     };
-    room->dataLoop();
+    room->loop();
     ASSERT_EQ(test_bool, false);
 
 
@@ -35,7 +35,7 @@ TEST(InputActionsTest, FunctionActionCalls){
             return true;
         return false;
     };
-    room->dataLoop();
+    room->loop();
     ASSERT_EQ(test_bool, true);
 }
 
@@ -52,20 +52,20 @@ TEST(InputActionsTest, MethodFunctionCalls){
             return false;
         };
 
-        room->dataLoop();
+        room->loop();
         EXPECT_EQ(element_b->getWorldPosition(), sf::Vector2f (0.0f, 0.0f));
 
         mate::isKeyPressed = [](sf::Keyboard::Key key){
             return true;
         };
-        room->dataLoop();
+        room->loop();
         EXPECT_EQ(element_b->getWorldPosition(), sf::Vector2f (5.0f, -2.0f));
         element_b->destroy();
     }
 
     EXPECT_EQ(input->getActionsCount(), 1);
-    room->dataLoop();
-    room->dataLoop();
+    room->loop();
+    room->loop();
     EXPECT_EQ(input->getActionsCount(), 0);
 }
 

--- a/tests/Triggers/test_Triggers.cpp
+++ b/tests/Triggers/test_Triggers.cpp
@@ -76,7 +76,7 @@ TEST(TriggersTest, TriggersTrackingOnManager){
     EXPECT_EQ(manager.triggerIsContained(id_b), true);
 
     manager.removeTrigger(id_a);
-    manager.curate();
+    manager.curateTriggers();
     EXPECT_EQ(manager.getListCount(), 1);
     EXPECT_EQ(manager.triggerIsContained(id_a), false);
     EXPECT_EQ(manager.triggerIsContained(id_b), true);
@@ -90,7 +90,7 @@ TEST(TriggersTest, TriggersTrackingOnManager){
     manager.addTrigger(std::move(trigger_c));
     EXPECT_EQ(manager.getListCount(), 2);
     EXPECT_EQ(manager.triggerIsContained(id_c), true);
-    manager.curate();
+    manager.curateTriggers();
     EXPECT_EQ(manager.getListCount(), 1);
     EXPECT_EQ(manager.triggerIsContained(id_c), false);
 }

--- a/tests/Triggers/test_Triggers.cpp
+++ b/tests/Triggers/test_Triggers.cpp
@@ -84,8 +84,8 @@ TEST(TriggersTest, TriggersTrackingOnManager){
 
     auto trigger_c = std::make_unique<mate::TestTrigger>();
     int id_c = trigger_c->getID();
-    trigger_c->markForRemoval();
-    EXPECT_EQ(trigger_c->shouldRemove(), true);
+    trigger_c->destroy();
+    EXPECT_EQ(trigger_c->shouldDestroy(), true);
 
     manager.addTrigger(std::move(trigger_c));
     EXPECT_EQ(manager.getListCount(), 2);
@@ -135,53 +135,53 @@ TEST(TriggersTest, TriggerActivation){
     shooter->setPositionOffset(0, 0);
     shooter->shape = mate::ShapeType::RECTANGLE;
 
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count);
 
     // RECTANGLE moving shooter to CIRCLE  static trigger
     element_b->setPosition(5, 5);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+1);
 
     element_b->setPosition(4, 4);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+2);
 
     element_b->setPosition(3.001, 3.001);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+2);
 
     // RECTANGLE moving shooter to RECTANGLE static trigger
     element_b->setPosition(-5, 5);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+3);
 
     element_b->setPosition(-6.999, 3.001);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+4);
 
     // RECTANGLE moving shooter to CIRCLE moving trigger
     element_b->setPosition(0, 0);
     element->setPosition(0, 0);
 
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+5);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+6);
 
     // CIRCLE moving trigger to CIRCLE static trigger
     shooter->shape = mate::ShapeType::CIRCLE;
 
     element_b->setPosition(5, 5);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+7);
 
     element_b->setPosition(4, 4);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+8);
 
     element_b->setPosition(3.001, 3.001);
-    room->dataLoop();
+    room->loop();
     EXPECT_EQ(mate::TestTrigger::count, starting_count+8);
 }
 


### PR DESCRIPTION
# What was done?

Several "interfaces" where created for classes to inherit from avoiding code repetition and allowing for better maintenance.

The specific interfaces are ILoop, containing virtual methods for loops and events; IDestroy, that has a flag and basic acces methods to track when an object must be destroyed without doing so instantly; and ILowLoop, which inherits from both ILoop and IDestroy and creates a way to differentiate high authority ILoops (Room) and the low authority ones (Element & Component).

# Why?

- **Better maintenance**: Adding new event or loop methods can now be done in one single class.
- **Reducing code repetition**: Since previously multiple classes required the same utilities that now are given by the new interfaces.
- **Increased abstraction**: Since now some container classes can have all of their Loop type children in one sinlge list while allowing for new usages (Such as Room now holding ILowLoops instead of Elements).

# How?

- The ILoop class was created with the following methods:
    - loop().
    - renderLoop().
    - windowResizeEvent().
- The following classes now inherit from ILoop:
    - Room.
    - ILowLoop.
- The IDestroy class was created with the following methods:
    - destroy().
    - shouldDestroy().
- The following classes now inherit from IDestroy:
    - Trigger.
    - ILowLoop.
- ILowLoop was made without variables nor methods, the following classes now inherit from ILowLoop:
    - Element.
    - Component.
- All the preexisting classes that used any of the methods now defined on their new base classes now ether use override or use the base methods.
- The list of Elements in Room was changed into a list of ILowLoops.
- The _parent variable on Component was turned from an Element weak pointer into a LocalCoords weak pointer.
- The lists _components and _elements on Element were combined in the _children list of ILowLoops.
- The loop() implementation on Element was adjusted to use the single _children list.
- The getter methods where modified to aknowledge this changes. Said methods where:
    - Room::getElementsCount: Now is only compiled on tests and was made a template and renamed into Room::getLoopTypeCount(), now being able to return the count of any specific type of contained ILowLoops.
    - Element::getElementsCount: Now performs some dynamic casting to ensure it only counts the Elements on the _children list.
    - Element::getFullElementsCount: Same changes as in Element::getElementsCount.

# Additional notes

## Class diagram

```mermaid
classDiagram
    class LC["LocalCoords"]{
        - parent LocalCoords
    }
    class D["IDestroy"]{
        # flag
        + destroy()
        + shouldDestroy()
    }
    class G["Game"]{
        - room_list
        - active_room
        + gameLoop()
    }
    class TM["TriggerManager"]{
        - triggers
        + addTrigger()
        + removeTrigger()
        + curateTriggers()
        + checkTriggers()
    }
    G--|>TM: inheritance
    class T["Trigger"]{
        - id
        + getID()
        + triggerIn() abstract
    }
    TM*--T: composition
    T--|>D
    class L["ILoop"]{
        + loop() abstract
        + renderLoop()
        + windowResizeEvent()
    }
    class LL["ILowLoop"]
    LL--|>D
    class C["Component"]{
        - parent LocalCoords
    }
    LL<|--C

    class E["Element"]{
        - children_list ILowLoop
        + addChild() Element
        + addComponent()
    }
    LC<|--E
    class R["Room"]{
        - children_list ILowLoop
    }
    R--|>TM
    R--|>L
    LL--|>L
    G*--R
    LC<|--R
    R*--LL
    E*--LL
    E--|>LL
    
    <<abstract>> L
    <<interface>> D
    <<abstract>> LL
    <<abstract>> T
```

## Improvements

- Room should have methods for the creation of Room level Components.
- Game could have a List of Elements or ILowLoops therefore making them persistent between Rooms.